### PR TITLE
Add no-cache header for main.jellyfin.bundle.js

### DIFF
--- a/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/10.11.0-rc5/StartupHelper_VersionSpecific.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/10.11.0-rc5/StartupHelper_VersionSpecific.cs
@@ -9,7 +9,9 @@ namespace Jellyfin.Plugin.FileTransformation.JellyfinVersionSpecific
         {
             options.OnPrepareResponse = (context) =>
             {
-                if (Path.GetFileName(context.File.Name).Equals("index.html", StringComparison.Ordinal))
+                var fileName = Path.GetFileName(context.File.Name);
+                if (fileName.Equals("index.html", StringComparison.OrdinalIgnoreCase) ||
+                    fileName.Equals("main.jellyfin.bundle.js", StringComparison.OrdinalIgnoreCase))
                 {
                     context.Context.Response.Headers.CacheControl = new StringValues("no-cache");
                 }

--- a/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/10.11.0/StartupHelper_VersionSpecific.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/10.11.0/StartupHelper_VersionSpecific.cs
@@ -9,12 +9,14 @@ namespace Jellyfin.Plugin.FileTransformation.JellyfinVersionSpecific
         {
             options.OnPrepareResponse = (context) =>
             {
-                if (Path.GetFileName(context.File.Name).Equals("index.html", StringComparison.Ordinal))
+                var fileName = Path.GetFileName(context.File.Name);
+                if (fileName.Equals("index.html", StringComparison.OrdinalIgnoreCase) ||
+                    fileName.Equals("main.jellyfin.bundle.js", StringComparison.OrdinalIgnoreCase))
                 {
                     context.Context.Response.Headers.CacheControl = new StringValues("no-cache");
                 }
             };
-            
+
             return options;
         }
     }


### PR DESCRIPTION
Updated StartupHelper_VersionSpecific.cs for Jellyfin 10.11.0 and 10.11.0-rc5 to also set the Cache-Control header to 'no-cache' for main.jellyfin.bundle.js, in addition to index.html.