### PR TITLE
fix: eliminate DI race condition that disables all file transformations

### DIFF
--- a/src/Jellyfin.Plugin.FileTransformation/Infrastructure/FileTransformationLogger.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/Infrastructure/FileTransformationLogger.cs
@@ -27,7 +27,7 @@ namespace Jellyfin.Plugin.FileTransformation.Infrastructure
         {
             if (logLevel < LogLevel.Information)
             {
-                if (FileTransformationPlugin.Instance.Configuration.DebugLoggingState == DebugLoggingState.Disabled)
+                if (FileTransformationPlugin.Instance?.Configuration?.DebugLoggingState == DebugLoggingState.Disabled)
                 {
                     return;
                 }

--- a/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
@@ -39,16 +39,15 @@ namespace Jellyfin.Plugin.FileTransformation
 
             logger?.LogInformation("[FileTransformation] Delegates set. Registering DI services...");
 
-            // Create instances eagerly so they are available to the Harmony prefix
+            // Create fresh instances eagerly so they are available to the Harmony prefix
             // on Startup.Configure() even if the DI container hasn't been built yet.
+            // Always recreate (not ??=) so in-process restarts get a clean state and
+            // stale transformations from a previous host build don't persist.
             if (loggerFactory != null)
             {
-                s_transformationLogger ??= new FileTransformationLogger(loggerFactory.CreateLogger<FileTransformationPlugin>());
-                s_transformationService ??= new WebFileTransformationService(s_transformationLogger);
-            }
+                s_transformationLogger = new FileTransformationLogger(loggerFactory.CreateLogger<FileTransformationPlugin>());
+                s_transformationService = new WebFileTransformationService(s_transformationLogger);
 
-            if (s_transformationService != null && s_transformationLogger != null)
-            {
                 // Register the pre-created instances so DI consumers get the same singletons.
                 serviceCollection.AddSingleton<WebFileTransformationService>(s_transformationService);
                 serviceCollection.AddSingleton<IWebFileTransformationReadService>(s_transformationService);
@@ -57,7 +56,8 @@ namespace Jellyfin.Plugin.FileTransformation
             }
             else
             {
-                // Fallback: let DI create the instances (original behavior).
+                // loggerFactory unavailable (should not happen in normal startup).
+                // Fall back to DI-managed creation (original behavior).
                 serviceCollection.AddSingleton<WebFileTransformationService>()
                     .AddSingleton<IWebFileTransformationReadService>(s => s.GetRequiredService<WebFileTransformationService>())
                     .AddSingleton<IWebFileTransformationWriteService>(s => s.GetRequiredService<WebFileTransformationService>());
@@ -69,10 +69,14 @@ namespace Jellyfin.Plugin.FileTransformation
 
         private IFileProvider GetFileTransformationFileProvider(IServerConfigurationManager serverConfigurationManager, IApplicationBuilder mainApplicationBuilder)
         {
-            // Prefer the eagerly-created instances (always available), fall back to DI.
-            IWebFileTransformationReadService? readService = s_transformationService
+            // Only use the eagerly-created instances when the plugin is actually active.
+            // During validation hosts FileTransformationPlugin.Instance is null, and the
+            // logger would NRE if we handed it to the file provider.
+            bool pluginActive = FileTransformationPlugin.Instance != null;
+
+            IWebFileTransformationReadService? readService = (pluginActive ? s_transformationService : null)
                 ?? mainApplicationBuilder.ApplicationServices.GetService<IWebFileTransformationReadService>();
-            IFileTransformationLogger? transformationLogger = s_transformationLogger
+            IFileTransformationLogger? transformationLogger = (pluginActive ? s_transformationLogger : null)
                 ?? mainApplicationBuilder.ApplicationServices.GetService<IFileTransformationLogger>();
 
             if (readService == null || transformationLogger == null)

--- a/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
@@ -15,6 +15,13 @@ namespace Jellyfin.Plugin.FileTransformation
 {
     public class PluginServiceRegistrator : IPluginServiceRegistrator
     {
+        // Pre-created singleton instances that survive regardless of DI container timing.
+        // The Harmony prefix on Startup.Configure() may fire before the DI container is
+        // fully built, causing GetService<T>() to return null even though RegisterServices
+        // already ran. By creating the instances eagerly here we eliminate the race.
+        private static WebFileTransformationService? s_transformationService;
+        private static IFileTransformationLogger? s_transformationLogger;
+
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
             IServerApplicationPaths? applicationPaths = (IServerApplicationPaths?)applicationHost.GetType().GetProperty("ApplicationPaths", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(applicationHost);
@@ -32,19 +39,41 @@ namespace Jellyfin.Plugin.FileTransformation
 
             logger?.LogInformation("[FileTransformation] Delegates set. Registering DI services...");
 
-            serviceCollection.AddSingleton<WebFileTransformationService>()
-                .AddSingleton<IWebFileTransformationReadService>(s => s.GetRequiredService<WebFileTransformationService>())
-                .AddSingleton<IWebFileTransformationWriteService>(s => s.GetRequiredService<WebFileTransformationService>());
+            // Create instances eagerly so they are available to the Harmony prefix
+            // on Startup.Configure() even if the DI container hasn't been built yet.
+            if (loggerFactory != null)
+            {
+                s_transformationLogger ??= new FileTransformationLogger(loggerFactory.CreateLogger<FileTransformationPlugin>());
+                s_transformationService ??= new WebFileTransformationService(s_transformationLogger);
+            }
 
-            serviceCollection.AddSingleton<IFileTransformationLogger, FileTransformationLogger>();
+            if (s_transformationService != null && s_transformationLogger != null)
+            {
+                // Register the pre-created instances so DI consumers get the same singletons.
+                serviceCollection.AddSingleton<WebFileTransformationService>(s_transformationService);
+                serviceCollection.AddSingleton<IWebFileTransformationReadService>(s_transformationService);
+                serviceCollection.AddSingleton<IWebFileTransformationWriteService>(s_transformationService);
+                serviceCollection.AddSingleton<IFileTransformationLogger>(s_transformationLogger);
+            }
+            else
+            {
+                // Fallback: let DI create the instances (original behavior).
+                serviceCollection.AddSingleton<WebFileTransformationService>()
+                    .AddSingleton<IWebFileTransformationReadService>(s => s.GetRequiredService<WebFileTransformationService>())
+                    .AddSingleton<IWebFileTransformationWriteService>(s => s.GetRequiredService<WebFileTransformationService>());
+                serviceCollection.AddSingleton<IFileTransformationLogger, FileTransformationLogger>();
+            }
 
             logger?.LogInformation("[FileTransformation] DI services registered successfully.");
         }
 
         private IFileProvider GetFileTransformationFileProvider(IServerConfigurationManager serverConfigurationManager, IApplicationBuilder mainApplicationBuilder)
         {
-            IWebFileTransformationReadService? readService = mainApplicationBuilder.ApplicationServices.GetService<IWebFileTransformationReadService>();
-            IFileTransformationLogger? transformationLogger = mainApplicationBuilder.ApplicationServices.GetService<IFileTransformationLogger>();
+            // Prefer the eagerly-created instances (always available), fall back to DI.
+            IWebFileTransformationReadService? readService = s_transformationService
+                ?? mainApplicationBuilder.ApplicationServices.GetService<IWebFileTransformationReadService>();
+            IFileTransformationLogger? transformationLogger = s_transformationLogger
+                ?? mainApplicationBuilder.ApplicationServices.GetService<IFileTransformationLogger>();
 
             if (readService == null || transformationLogger == null)
             {

--- a/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
@@ -69,14 +69,11 @@ namespace Jellyfin.Plugin.FileTransformation
 
         private IFileProvider GetFileTransformationFileProvider(IServerConfigurationManager serverConfigurationManager, IApplicationBuilder mainApplicationBuilder)
         {
-            // Only use the eagerly-created instances when the plugin is actually active.
-            // During validation hosts FileTransformationPlugin.Instance is null, and the
-            // logger would NRE if we handed it to the file provider.
-            bool pluginActive = FileTransformationPlugin.Instance != null;
-
-            IWebFileTransformationReadService? readService = (pluginActive ? s_transformationService : null)
+            // Prefer the eagerly-created instances (always available regardless of DI
+            // container timing), fall back to DI resolution as a last resort.
+            IWebFileTransformationReadService? readService = s_transformationService
                 ?? mainApplicationBuilder.ApplicationServices.GetService<IWebFileTransformationReadService>();
-            IFileTransformationLogger? transformationLogger = (pluginActive ? s_transformationLogger : null)
+            IFileTransformationLogger? transformationLogger = s_transformationLogger
                 ?? mainApplicationBuilder.ApplicationServices.GetService<IFileTransformationLogger>();
 
             if (readService == null || transformationLogger == null)

--- a/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
@@ -20,7 +20,7 @@ namespace Jellyfin.Plugin.FileTransformation
         // fully built, causing GetService<T>() to return null even though RegisterServices
         // already ran. By creating the instances eagerly here we eliminate the race.
         private static WebFileTransformationService? s_transformationService;
-        private static IFileTransformationLogger? s_transformationLogger;
+        private static FileTransformationLogger? s_transformationLogger;
 
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {


### PR DESCRIPTION
## Summary

Fixes the intermittent "File transformations are DISABLED" warning that causes all plugin script injections to silently stop working on some server restarts, as reported in #48.

```
[INF] [FileTransformation] RegisterServices called. Initializing module...
[INF] [FileTransformation] DI services registered successfully.
...
[WRN] IWebFileTransformationReadService or IFileTransformationLogger not found in DI container.
      File transformations are DISABLED. Falling back to default PhysicalFileProvider.
```

When this triggers, ALL plugins depending on File Transformation (Jellyfin Enhanced, JellyTweaks, JavaScript Injector, Home Screen Sections, etc.) lose their script injection -- the server runs but no plugin UI appears.

## Root Cause

The Harmony prefix on `Startup.Configure()` invokes `GetFileTransformationFileProvider()` which resolves `IWebFileTransformationReadService` and `IFileTransformationLogger` from `mainApplicationBuilder.ApplicationServices`.

On some restarts, this fires before the DI container is fully built from the `IServiceCollection`. The services were registered via `AddSingleton` in `RegisterServices()`, but the `IServiceProvider` available to the Harmony prefix doesn't contain them yet -- `GetService<T>()` returns `null`, triggering the `PhysicalFileProvider` fallback.

This is non-deterministic: it depends on thread scheduling and plugin load order during startup. Some restarts work, some don't.

## Changes

### `PluginServiceRegistrator.cs`
- **Create service instances eagerly** during `RegisterServices()` and store as `private static` fields (`s_transformationService`, `s_transformationLogger`). This makes them available to `GetFileTransformationFileProvider()` regardless of DI container timing.
- **Register the pre-created instances** in DI via `AddSingleton<T>(instance)` so all DI consumers (including `FileTransformationPlugin` constructor and `PluginInterface.RegisterTransformation()`) receive the same singleton.
- **Always recreate** on each `RegisterServices()` call (not `??=`) so in-process restarts get clean state without stale transformations persisting.
- `GetFileTransformationFileProvider()` now prefers the static instances, falling back to DI resolution as a last resort.
- If `loggerFactory` is unavailable (should not happen in normal startup), falls back to the original DI-managed creation.

### `FileTransformationLogger.cs`
- Added null-conditional (`?.`) on `FileTransformationPlugin.Instance?.Configuration?.DebugLoggingState` in `Log()`. During early startup the eagerly-created logger may be invoked before `FileTransformationPlugin.Instance` is assigned (its constructor requires DI). Without this guard, a `NullReferenceException` would crash the server.

## Verification

Tested on Jellyfin 10.11.7 (Docker, linuxserver.io image):
- 5/5 consecutive rapid restarts: zero DISABLED warnings, script tags present every time
- Jellyfin Enhanced, JellyTweaks, JavaScript Injector all load correctly after each restart
- Full Playwright E2E verification: plugin UI renders, tags display, settings panel opens
- Singleton identity verified: `PluginInterface.RegisterTransformation()` and DI resolution both access the same `WebFileTransformationService` instance
- Reviewed by Claude code-reviewer, Claude security-reviewer, and OpenAI Codex (GPT-5.4) across two review passes