### PR TITLE
fix: make DI service registrations unconditional to prevent regression

### DIFF
--- a/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/PluginServiceRegistrator.cs
@@ -39,16 +39,39 @@ namespace Jellyfin.Plugin.FileTransformation
 
             logger?.LogInformation("[FileTransformation] Delegates set. Registering DI services...");
 
-            // Create fresh instances eagerly so they are available to the Harmony prefix
+            // Try to create instances eagerly so they are available to the Harmony prefix
             // on Startup.Configure() even if the DI container hasn't been built yet.
-            // Always recreate (not ??=) so in-process restarts get a clean state and
-            // stale transformations from a previous host build don't persist.
+            // Old statics are kept until replacements are ready so concurrent Harmony
+            // prefix calls never observe a null window during in-process restarts.
             if (loggerFactory != null)
             {
-                s_transformationLogger = new FileTransformationLogger(loggerFactory.CreateLogger<FileTransformationPlugin>());
-                s_transformationService = new WebFileTransformationService(s_transformationLogger);
+                try
+                {
+                    var tempLogger = new FileTransformationLogger(loggerFactory.CreateLogger<FileTransformationPlugin>());
+                    var tempService = new WebFileTransformationService(tempLogger);
+                    s_transformationLogger = tempLogger;
+                    s_transformationService = tempService;
+                }
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                {
+                    logger?.LogError(ex, "[FileTransformation] Eager instance creation failed. " +
+                        "DI-managed creation will be attempted as fallback but may also fail for the same reason.");
+                    s_transformationLogger = null;
+                    s_transformationService = null;
+                }
+            }
+            else
+            {
+                // loggerFactory unavailable -- clear statics since we cannot create
+                // fresh instances and must not carry stale ones into the new host.
+                s_transformationService = null;
+                s_transformationLogger = null;
+            }
 
-                // Register the pre-created instances so DI consumers get the same singletons.
+            // DI registrations always happen via one of two paths: pre-created
+            // instances when available, or DI-managed factory creation as fallback.
+            if (s_transformationService != null && s_transformationLogger != null)
+            {
                 serviceCollection.AddSingleton<WebFileTransformationService>(s_transformationService);
                 serviceCollection.AddSingleton<IWebFileTransformationReadService>(s_transformationService);
                 serviceCollection.AddSingleton<IWebFileTransformationWriteService>(s_transformationService);
@@ -56,8 +79,6 @@ namespace Jellyfin.Plugin.FileTransformation
             }
             else
             {
-                // loggerFactory unavailable (should not happen in normal startup).
-                // Fall back to DI-managed creation (original behavior).
                 serviceCollection.AddSingleton<WebFileTransformationService>()
                     .AddSingleton<IWebFileTransformationReadService>(s => s.GetRequiredService<WebFileTransformationService>())
                     .AddSingleton<IWebFileTransformationWriteService>(s => s.GetRequiredService<WebFileTransformationService>());


### PR DESCRIPTION
## Summary

Sorry about this one -- the regression was introduced by my PR #52. Oops!

PR #52 wrapped the DI service registrations inside `if (loggerFactory != null)`, making them conditional on a reflected LoggerFactory being available. If the reflection failed or if eager instance creation threw, the DI registrations never executed and the Harmony prefix found no services, disabling all file transformations deterministically.

This fix separates eager creation (optional, best-effort) from DI registration (always happens via one of two paths). When eager instances are available they are registered directly; otherwise the original DI-managed factory registration is used as fallback. This restores the 2.5.7.0 guarantee that services are always registered while preserving the race-condition fix from #52.

Closes #55

## Changes

**`PluginServiceRegistrator.cs`** (+29/-8):
- Eager instance creation wrapped in try/catch with exception filter (excludes OOM/StackOverflow)
- Locals-first pattern to avoid partial static assignment visible to concurrent Harmony prefix calls
- Old statics kept until replacements are ready (no null window during in-process restarts)
- DI registrations decoupled from the `loggerFactory != null` check -- always happen unconditionally
- Log severity escalated from Warning to Error for eager creation failures

## Test plan

- [x] Built with `dotnet build` -- 0 warnings, 0 errors
- [x] Deployed and tested on Jellyfin 10.11.x dev instance (Docker)
- [x] 5 consecutive restarts with zero "DISABLED" warnings
- [x] All downstream plugins (Jellyfin Enhanced, JellyTweaks, JavaScript Injector) register transformations correctly after each restart
- [x] Verified script tags are actively injected into served HTML
- [x] Reviewed by Claude code-reviewer, silent-failure-hunter, and OpenAI Codex (GPT-5.4) -- 5 review passes, 2 consecutive clean passes from all 3 reviewers

This PR was developed with AI assistance (Claude/GPT). All changes have been reviewed, tested, and understood.