### PR TITLE
fix: resolve DI services eagerly to prevent ObjectDisposedException (captive dependency)

### DIFF
--- a/src/Jellyfin.Plugin.FileTransformation/PluginInterface.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/PluginInterface.cs
@@ -19,11 +19,15 @@ namespace Jellyfin.Plugin.FileTransformation
 
             if (castedPayload != null)
             {
+                // Resolve services eagerly at registration time. The ServiceProvider captured
+                // by the plugin is scoped and will be disposed after startup. Resolving lazily
+                // inside the callback causes ObjectDisposedException on every subsequent request.
+                // Both ILogger and IServerApplicationHost are singletons, so capturing them here is safe.
+                ILogger logger = FileTransformationPlugin.Instance.ServiceProvider.GetRequiredService<IFileTransformationLogger>();
+                IServerApplicationHost serverApplicationHost = FileTransformationPlugin.Instance.ServiceProvider.GetRequiredService<IServerApplicationHost>();
+
                 writeService.AddTransformation(castedPayload.Id, castedPayload.FileNamePattern, async (path, contents) =>
                 {
-                    ILogger logger = FileTransformationPlugin.Instance.ServiceProvider.GetRequiredService<IFileTransformationLogger>();
-                    IServerApplicationHost serverApplicationHost = FileTransformationPlugin.Instance.ServiceProvider.GetRequiredService<IServerApplicationHost>();
-                    
                     await TransformationHelper.ApplyTransformation(path, contents, castedPayload, logger, serverApplicationHost);
                 });
             }


### PR DESCRIPTION
## Problem

After the DI scope is disposed post-startup, every web request crashes with:

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'IServiceProvider'.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.ThrowHelper.ThrowObjectDisposedException()
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
   at Jellyfin.Plugin.FileTransformation.PluginInterface.<>c__DisplayClass0_0.<<RegisterTransformation>b__0>d.MoveNext()
   at Jellyfin.Plugin.FileTransformation.Infrastructure.WebFileTransformationService.RunTransformation(String path, Stream stream)
   at Jellyfin.Plugin.FileTransformation.Infrastructure.PhysicalTransformedFileProvider.GetFileInfo(String subpath)
```

This breaks the entire static file pipeline — `GET /web/` returns HTTP 500 and Jellyfin is completely inaccessible. The issue is intermittent because it only triggers after the scoped `IServiceProvider` is collected/disposed, which can take hours or days depending on GC pressure.

## Root Cause

In `PluginInterface.RegisterTransformation`, the callback delegate captures `FileTransformationPlugin.Instance.ServiceProvider` and resolves `ILogger` and `IServerApplicationHost` lazily at execution time (i.e. on every web request).

However, the `IServiceProvider` injected into `FileTransformationPlugin` is **scoped**. After Jellyfin finishes its startup/plugin registration phase, this scope is disposed. Every subsequent `GetRequiredService` call inside the callback throws `ObjectDisposedException`.

This is a classic **captive dependency** bug — a scoped service is captured and held beyond its intended lifetime.

## Fix

Resolve `ILogger` and `IServerApplicationHost` **eagerly** at registration time (before scope disposal) and capture the instances in the closure.

Both services are registered as **singletons** in Jellyfin's DI container, so capturing them at registration time is safe — they outlive any scope.

## Testing

Built against Jellyfin 10.11.11 (.NET 9), deployed to a live Jellyfin instance that was previously throwing 386+ `ObjectDisposedException`s. After deploying the fix:
- Plugin loads and registers DI services successfully
- Dependent plugins (InPlayerEpisodePreview, AchievementBadges, etc.) register transformations without error
- Zero `ObjectDisposedException`s in logs
- `GET /web/` returns HTTP 200
- Instance has been stable with plugin active

Fixes #66
Related: #61, #55 (prior DI scope issues with this plugin)