### PR TITLE
Add Jellyfin 12.0 build target

### DIFF
--- a/src/Jellyfin.Plugin.FileTransformation/FileTransformationPlugin.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/FileTransformationPlugin.cs
@@ -1,4 +1,4 @@
-﻿using Jellyfin.Plugin.FileTransformation.Configuration;
+using Jellyfin.Plugin.FileTransformation.Configuration;
 using Jellyfin.Plugin.FileTransformation.Library;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
@@ -23,6 +23,11 @@ namespace Jellyfin.Plugin.FileTransformation
             Instance = this;
             
             ServiceProvider = serviceProvider;
+
+            // Replay any transformations registered by other plugins before this
+            // constructor ran. On Jellyfin 12.0 consumer IHostedServices can start
+            // before the plugin is constructed. See PluginInterface.s_pending.
+            PluginInterface.DrainPending(serviceProvider);
 
             foreach (PluginDefinedTransformation transformation in Configuration.Transformations)
             {

--- a/src/Jellyfin.Plugin.FileTransformation/Jellyfin.Plugin.FileTransformation.csproj
+++ b/src/Jellyfin.Plugin.FileTransformation/Jellyfin.Plugin.FileTransformation.csproj
@@ -1,13 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <JellyfinVersion>10.11.3</JellyfinVersion>
+        <JellyfinVersion Condition="'$(JellyfinVersion)' == ''">12.0.0</JellyfinVersion>
         <JellyfinNugetVersion Condition="!$(JellyfinVersion.StartsWith('10.11'))">$(JellyfinVersion)</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11'))">$(JellyfinVersion)</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11.1'))">10.11.0</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11.0'))">10.11.0</JellyfinNugetVersion>
+        <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('12.'))">12.0.0-rc5</JellyfinNugetVersion>
         <TargetFramework Condition="$(JellyfinVersion.StartsWith('10.11'))">net9.0</TargetFramework>
         <TargetFramework Condition="'$(JellyfinVersion)' == '10.10.7'">net8.0</TargetFramework>
+        <TargetFramework Condition="$(JellyfinVersion.StartsWith('12.'))">net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -20,6 +22,16 @@ This plugin is based on a Pull Request (https://github.com/jellyfin/jellyfin/pul
         <Version>2.5.0.0 </Version>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <!-- Harmony 2.4.0 throws PlatformNotSupportedException on CoreCLR 10.
+             2.4.2 ships a net10.0 target. Bump only for Jellyfin 12.x. -->
+        <HarmonyVersion>2.4.0</HarmonyVersion>
+        <HarmonyVersion Condition="$(JellyfinVersion.StartsWith('12.'))">2.4.2</HarmonyVersion>
+        <HarmonyTfm>net8.0</HarmonyTfm>
+        <HarmonyTfm Condition="$(JellyfinVersion.StartsWith('12.'))">net10.0</HarmonyTfm>
+    </PropertyGroup>
+
+
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         
@@ -28,7 +40,7 @@ This plugin is based on a Pull Request (https://github.com/jellyfin/jellyfin/pul
       <PackageReference Include="Jellyfin.Data" Version="$(JellyfinNugetVersion)" />
       <PackageReference Include="Jellyfin.Extensions" Version="$(JellyfinNugetVersion)" />
 
-      <PackageReference Include="Lib.Harmony" Version="2.4.0" GeneratePathProperty="true" />
+      <PackageReference Include="Lib.Harmony" Version="$(HarmonyVersion)" GeneratePathProperty="true" />
 
       <PackageReference Include="prometheus-net" Version="8.2.1" />
       <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
@@ -36,7 +48,7 @@ This plugin is based on a Pull Request (https://github.com/jellyfin/jellyfin/pul
     </ItemGroup>
 
     <ItemGroup>
-      <EmbeddedResource Include="$(PkgLib_Harmony)\lib\net8.0\0Harmony.dll" />
+      <EmbeddedResource Include="$(PkgLib_Harmony)\lib\$(HarmonyTfm)\0Harmony.dll" />
       <EmbeddedResource Include="Configuration\config.html" />
     </ItemGroup>
     
@@ -65,5 +77,12 @@ This plugin is based on a Pull Request (https://github.com/jellyfin/jellyfin/pul
         <Exec Condition="$(JellyfinVersion.StartsWith('10.11'))" Command="xcopy &quot;$(OutDir)$(TargetName).*&quot; &quot;C:\ProgramData\Jellyfin\Server_10_11\plugins\FileTransformation&quot; /y" />
         <Exec Condition="'$(JellyfinVersion)' == '10.10.7'"     Command="xcopy &quot;$(OutDir)$(TargetName).*&quot; &quot;C:\ProgramData\Jellyfin\Server_10_10_7\plugins\FileTransformation&quot; /y" />
     </Target>
+
+
+    <!-- Remove 12.0 Specific Code from non 12.x builds -->
+    <ItemGroup Condition="!$(JellyfinVersion.StartsWith('12.'))">
+        <None Include="JellyfinVersionSpecific/12.0/*.cs" />
+        <Compile Remove="JellyfinVersionSpecific/12.0/*.cs" />
+    </ItemGroup>
 
 </Project>

--- a/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/12.0/StartupHelper_VersionSpecific.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/12.0/StartupHelper_VersionSpecific.cs
@@ -1,0 +1,24 @@
+﻿using Jellyfin.Plugin.FileTransformation.Library;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Primitives;
+
+namespace Jellyfin.Plugin.FileTransformation.JellyfinVersionSpecific
+{
+    public static class StartupHelper_VersionSpecific
+    {
+        public static StaticFileOptions ConfigureVersionSpecific(this StaticFileOptions options)
+        {
+            options.OnPrepareResponse = (context) =>
+            {
+                var fileName = Path.GetFileName(context.File.Name);
+                if (fileName.Equals("index.html", StringComparison.OrdinalIgnoreCase) ||
+                    fileName.Equals("main.jellyfin.bundle.js", StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Context.Response.Headers.CacheControl = new StringValues("no-cache");
+                }
+            };
+
+            return options;
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.FileTransformation/PluginInterface.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/PluginInterface.cs
@@ -1,4 +1,5 @@
-﻿using Jellyfin.Plugin.FileTransformation.Helpers;
+using System.Collections.Concurrent;
+using Jellyfin.Plugin.FileTransformation.Helpers;
 using Jellyfin.Plugin.FileTransformation.Library;
 using Jellyfin.Plugin.FileTransformation.Models;
 using MediaBrowser.Controller;
@@ -10,10 +11,48 @@ namespace Jellyfin.Plugin.FileTransformation
 {
     public static class PluginInterface
     {
+        /// <summary>
+        /// Registrations received before this plugin's own constructor has run.
+        ///
+        /// Consumers (Intro Skipper, Home Screen Sections, ...) call RegisterTransformation from
+        /// their IHostedService.StartAsync. On Jellyfin 12.0 that can run BEFORE Jellyfin has
+        /// constructed FileTransformationPlugin, so Instance is still null. Previously this threw
+        /// a NullReferenceException which propagated out of the hosted service and aborted server
+        /// startup entirely - one consumer plugin could take the whole server down.
+        ///
+        /// Early calls are queued here instead and replayed by DrainPending() from the constructor.
+        /// </summary>
+        private static readonly ConcurrentQueue<JObject> s_pending = new();
+
         public static void RegisterTransformation(JObject payload)
         {
-            IWebFileTransformationWriteService writeService = FileTransformationPlugin.Instance.ServiceProvider
-                .GetRequiredService<IWebFileTransformationWriteService>();
+            FileTransformationPlugin? plugin = FileTransformationPlugin.Instance;
+
+            if (plugin?.ServiceProvider is null)
+            {
+                s_pending.Enqueue(payload);
+                return;
+            }
+
+            Register(plugin.ServiceProvider, payload);
+        }
+
+        /// <summary>
+        /// Replay any registrations that arrived before the plugin was constructed.
+        /// Called from FileTransformationPlugin's constructor once ServiceProvider is available.
+        /// </summary>
+        internal static void DrainPending(IServiceProvider serviceProvider)
+        {
+            while (s_pending.TryDequeue(out JObject? queued))
+            {
+                Register(serviceProvider, queued);
+            }
+        }
+
+        private static void Register(IServiceProvider serviceProvider, JObject payload)
+        {
+            IWebFileTransformationWriteService writeService =
+                serviceProvider.GetRequiredService<IWebFileTransformationWriteService>();
 
             TransformationRegistrationPayload? castedPayload = payload.ToObject<TransformationRegistrationPayload>();
 
@@ -23,8 +62,8 @@ namespace Jellyfin.Plugin.FileTransformation
                 // by the plugin is scoped and will be disposed after startup. Resolving lazily
                 // inside the callback causes ObjectDisposedException on every subsequent request.
                 // Both ILogger and IServerApplicationHost are singletons, so capturing them here is safe.
-                ILogger logger = FileTransformationPlugin.Instance.ServiceProvider.GetRequiredService<IFileTransformationLogger>();
-                IServerApplicationHost serverApplicationHost = FileTransformationPlugin.Instance.ServiceProvider.GetRequiredService<IServerApplicationHost>();
+                ILogger logger = serviceProvider.GetRequiredService<IFileTransformationLogger>();
+                IServerApplicationHost serverApplicationHost = serviceProvider.GetRequiredService<IServerApplicationHost>();
 
                 writeService.AddTransformation(castedPayload.Id, castedPayload.FileNamePattern, async (path, contents) =>
                 {


### PR DESCRIPTION
Adds a Jellyfin 12.0 build target and fixes two issues that stop the plugin working there.

**12.0 target** - teaches the existing `<JellyfinVersion>` matrix about 12.x: NuGet `12.0.0-rc5`,
`TargetFramework` `net10.0`, and a `JellyfinVersionSpecific/12.0/` shim seeded from the 10.11 one.
The 10.10.7 and 10.11 targets are untouched and still build.

**Harmony 2.4.0 aborts on .NET 10.** It throws
`PlatformNotSupportedException: CoreCLR version 10.0.x is not supported` from
`HarmonyLib.PatchFunctions.UpdateWrapper`, which Jellyfin surfaces only as the plugin being
"Malfunctioned" with almost nothing in the log. Lib.Harmony 2.4.2 ships a `net10.0` target and
drops that guard; bumped for the 12.x target only via `$(HarmonyVersion)` / `$(HarmonyTfm)`.

**A consumer plugin could take the whole server down.** Consumers (Intro Skipper, Home Screen
Sections, ...) call `PluginInterface.RegisterTransformation` from their `IHostedService.StartAsync`.
On Jellyfin 12 that can run *before* Jellyfin constructs `FileTransformationPlugin`, so `Instance`
was still null. The resulting `NullReferenceException` propagated out of the hosted service and
aborted server startup (`Kestrel failed to start`). Early registrations are now queued and replayed
from the constructor.

Tested against Jellyfin 12.0-rc5 with six dependent plugins loading and 26 transformations registered.
