### PR TITLE
Disables absolute cache for static files

### DIFF
--- a/src/Jellyfin.Plugin.FileTransformation/Infrastructure/PhysicalTransformedFileProvider.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/Infrastructure/PhysicalTransformedFileProvider.cs
@@ -53,7 +53,11 @@ namespace Jellyfin.Plugin.FileTransformation.Infrastructure
                 m_webFileTransformationService.RunTransformation(subpath, transformedStream).GetAwaiter().GetResult();
                 transformedStream.Seek(0, SeekOrigin.Begin);
 
-                return new TransformableFileInfo(physicalFileInfo.Exists ? physicalFileInfo : null, transformedStream, physicalFileInfo.Exists ? null : subpath);
+                return new TransformableFileInfo(
+                    physicalFileInfo.Exists ? physicalFileInfo : null,
+                    transformedStream,
+                    m_webFileTransformationService.GetLastModified(physicalFileInfo.Exists ? physicalFileInfo.LastModified : null),
+                    physicalFileInfo.Exists ? null : subpath);
             }
             
             return iFileInfo;

--- a/src/Jellyfin.Plugin.FileTransformation/Infrastructure/TransformableFileInfo.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/Infrastructure/TransformableFileInfo.cs
@@ -7,12 +7,14 @@ namespace Jellyfin.Plugin.FileTransformation.Infrastructure
     {
         private readonly PhysicalFileInfo? m_baseInfo;
         private readonly Stream m_transformedStream;
+        private readonly DateTimeOffset m_lastModified;
         private readonly string? m_nameOverride;
 
-        public TransformableFileInfo(PhysicalFileInfo? baseInfo, Stream transformedStream, string? nameOverride = null)
+        public TransformableFileInfo(PhysicalFileInfo? baseInfo, Stream transformedStream, DateTimeOffset lastModified, string? nameOverride = null)
         {
             m_baseInfo = baseInfo;
             m_transformedStream = transformedStream;
+            m_lastModified = lastModified;
             m_nameOverride = nameOverride;
         }
 
@@ -20,7 +22,7 @@ namespace Jellyfin.Plugin.FileTransformation.Infrastructure
 
         public bool IsDirectory => m_baseInfo?.IsDirectory ?? false;
 
-        public DateTimeOffset LastModified => m_baseInfo?.LastModified ?? DateTimeOffset.Now;
+        public DateTimeOffset LastModified => m_lastModified;
 
         public long Length => m_transformedStream.Length;
 

--- a/src/Jellyfin.Plugin.FileTransformation/Infrastructure/WebFileTransformationService.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/Infrastructure/WebFileTransformationService.cs
@@ -9,10 +9,16 @@ namespace Jellyfin.Plugin.FileTransformation.Infrastructure
     {
         private readonly ConcurrentDictionary<string, ICollection<(Guid TransformId, TransformFile Delegate)>> m_fileTransformations = new ConcurrentDictionary<string, ICollection<(Guid TransformId, TransformFile Delegate)>>();
         private readonly ILogger<FileTransformationPlugin> m_logger;
+        private readonly DateTimeOffset m_startedAt = DateTimeOffset.FromUnixTimeSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
 
         public WebFileTransformationService(IFileTransformationLogger logger)
         {
             m_logger = logger;
+        }
+
+        public DateTimeOffset GetLastModified(DateTimeOffset? baseLastModified)
+        {
+            return baseLastModified > m_startedAt ? baseLastModified.Value : m_startedAt;
         }
         
         private string NormalizePath(string path)

--- a/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/10.10.7/StartupHelper_VersionSpecific.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/10.10.7/StartupHelper_VersionSpecific.cs
@@ -9,10 +9,7 @@ namespace Jellyfin.Plugin.FileTransformation.JellyfinVersionSpecific
         {
             options.OnPrepareResponse = (context) =>
             {
-                if (Path.GetFileName(context.File.Name).Equals("index.html", StringComparison.Ordinal))
-                {
-                    context.Context.Response.Headers.CacheControl = new StringValues("no-cache");
-                }
+                context.Context.Response.Headers.CacheControl = new StringValues("no-cache");
             };
             
             return options;

--- a/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/10.11/StartupHelper_VersionSpecific.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/JellyfinVersionSpecific/10.11/StartupHelper_VersionSpecific.cs
@@ -1,5 +1,4 @@
-﻿using Jellyfin.Plugin.FileTransformation.Library;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Primitives;
 
 namespace Jellyfin.Plugin.FileTransformation.JellyfinVersionSpecific
@@ -10,12 +9,7 @@ namespace Jellyfin.Plugin.FileTransformation.JellyfinVersionSpecific
         {
             options.OnPrepareResponse = (context) =>
             {
-                var fileName = Path.GetFileName(context.File.Name);
-                if (fileName.Equals("index.html", StringComparison.OrdinalIgnoreCase) ||
-                    fileName.Equals("main.jellyfin.bundle.js", StringComparison.OrdinalIgnoreCase))
-                {
-                    context.Context.Response.Headers.CacheControl = new StringValues("no-cache");
-                }
+                context.Context.Response.Headers.CacheControl = new StringValues("no-cache");
             };
 
             return options;

--- a/src/Jellyfin.Plugin.FileTransformation/Library/IWebFileTransformationReadService.cs
+++ b/src/Jellyfin.Plugin.FileTransformation/Library/IWebFileTransformationReadService.cs
@@ -2,6 +2,8 @@
 {
     public interface IWebFileTransformationReadService
     {
+        DateTimeOffset GetLastModified(DateTimeOffset? baseLastModified);
+
         bool NeedsTransformation(string path);
 
         Task RunTransformation(string path, Stream stream);


### PR DESCRIPTION
I have the problem, that when I update my plugins, users doesn't see any changes in the UI caused by browser cache.

This PR makes browser send requests to the server before reusing the cache. Cache now based on service startup time.

I know that this potentially can slow down a responsiveness a bit (since client need to reach the server instead of local file cache), but delivering proper content to the user is more important then just quickly serve expired cache.